### PR TITLE
Guard SessionManager when HttpContext is unavailable

### DIFF
--- a/OLIWeb/Klassen/IUserSession.cs
+++ b/OLIWeb/Klassen/IUserSession.cs
@@ -1,0 +1,15 @@
+using OliEngine.OliMiddleTier.OLIs;
+
+namespace OliWeb.Klassen
+{
+    /// <summary>
+    ///     Represents the current user context for the application.
+    /// </summary>
+    public interface IUserSession
+    {
+        /// <summary>
+        ///     Gets the current <see cref="OliUser" />.
+        /// </summary>
+        OliUser OliUser { get; }
+    }
+}

--- a/OLIWeb/OliWeb.csproj
+++ b/OLIWeb/OliWeb.csproj
@@ -1002,6 +1002,9 @@
     <Compile Include="Klassen\MasterTopLabPage.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Klassen\IUserSession.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Klassen\SessionManager.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/nulllogicone.net/Klassen/IUserSession.cs
+++ b/nulllogicone.net/Klassen/IUserSession.cs
@@ -1,0 +1,15 @@
+using OliEngine.OliMiddleTier.OLIs;
+
+namespace OliWeb.Klassen
+{
+    /// <summary>
+    ///     Represents the current user context for the application.
+    /// </summary>
+    public interface IUserSession
+    {
+        /// <summary>
+        ///     Gets the current <see cref="OliUser" />.
+        /// </summary>
+        OliUser OliUser { get; }
+    }
+}

--- a/nulllogicone.net/Klassen/SessionManager.cs
+++ b/nulllogicone.net/Klassen/SessionManager.cs
@@ -2,21 +2,24 @@
 // (c) frederic@luchting.de
 // --------------------------
 //  
+using System.Threading;
 using System.Web;
 using OliEngine.OliMiddleTier.OLIs;
 
 namespace OliWeb.Klassen
 {
     /// <summary>
-    ///     Über den SessionManager wird eine singleton Instanz des OliUser abgerufen.
+    ///     Ãœber den SessionManager wird eine singleton Instanz des OliUser abgerufen.
     /// </summary>
     /// <example>
-    ///     Im Code wird meistens eine OliUser Objektinstanz benötigt.
+    ///     Im Code wird meistens eine OliUser Objektinstanz benÃ¶tigt.
     ///     <code>OliUser user = SessionManager.Instance().OliUser;</code>
     /// </example>
-    public class SessionManager
+    public class SessionManager : IUserSession
     {
-        private OliEngine.OliMiddleTier.OLIs.OliUser user;
+        private static readonly AsyncLocal<SessionManager> AmbientSession = new AsyncLocal<SessionManager>();
+
+        private OliUser user;
 
         /// <summary>
         ///     Singleton Konstruktor ist private
@@ -34,14 +37,40 @@ namespace OliWeb.Klassen
         {
             HttpContext ctx = HttpContext.Current;
 
-            SessionManager sm = (SessionManager) ctx.Session["sm"];
-            if (sm == null)
+            if (ctx?.Session != null)
             {
-                sm = new SessionManager();
-                ctx.Session["sm"] = sm;
+                SessionManager sm = ctx.Session["sm"] as SessionManager;
+                if (sm == null)
+                {
+                    sm = new SessionManager();
+                    ctx.Session["sm"] = sm;
+                }
+
+                AmbientSession.Value = sm;
+                return sm;
             }
-            return (sm);
+
+            if (AmbientSession.Value == null)
+            {
+                AmbientSession.Value = new SessionManager();
+            }
+
+            return AmbientSession.Value;
         }
+
+        /// <summary>
+        ///     Allows code running outside an HTTP request (e.g. unit tests) to replace the ambient session.
+        /// </summary>
+        /// <param name="session">The session instance to use for the current asynchronous flow.</param>
+        public static void SetAmbientSession(SessionManager session)
+        {
+            AmbientSession.Value = session;
+        }
+
+        /// <summary>
+        ///     Returns <c>true</c> when the current execution context has access to <see cref="HttpContext" /> and <see cref="HttpSessionState" />.
+        /// </summary>
+        public static bool HasHttpContext => HttpContext.Current?.Session != null;
 
         /// <summary>
         ///     das aktuelle Mittelschicht Objekt. Wenn noch kein OliUser existiert,
@@ -51,11 +80,7 @@ namespace OliWeb.Klassen
         {
             get
             {
-                if (user == null)
-                {
-                    user = new OliUser();
-                }
-                return (user);
+                return user ?? (user = new OliUser());
             }
         }
     }

--- a/nulllogicone.net/nulllogicone.net.csproj
+++ b/nulllogicone.net/nulllogicone.net.csproj
@@ -548,6 +548,7 @@
     </Compile>
     <Compile Include="Klassen\Counter.cs" />
     <Compile Include="Klassen\Helper.cs" />
+    <Compile Include="Klassen\IUserSession.cs" />
     <Compile Include="Klassen\MasterControl.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>


### PR DESCRIPTION
## Summary
- add an IUserSession abstraction shared by the WebForms projects
- guard SessionManager.Instance() against missing HttpContext/Session and allow an ambient fallback for background flows
- update project files to include the new interface

## Testing
- msbuild nulllogicone.net.sln /t:Build /p:Configuration=Debug *(fails: msbuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ba3e76ec833082abfc0897f6f448